### PR TITLE
Allow the suffix to be manually set

### DIFF
--- a/lib/option_parser.ex
+++ b/lib/option_parser.ex
@@ -63,10 +63,10 @@ defmodule EctoResource.OptionParser do
 
   @spec create_suffix(module, list()) :: String.t()
   def create_suffix(schema, options) when is_list(options) do
-    if Keyword.get(options, :suffix) == false do
-      ""
-    else
-      Helpers.underscore_module_name(schema)
+    case Keyword.get(options, :suffix) do
+      false -> ""
+      manual when is_binary(manual) -> manual
+      _ -> Helpers.underscore_module_name(schema)
     end
   end
 

--- a/test/ecto_resource/option_parser_test.exs
+++ b/test/ecto_resource/option_parser_test.exs
@@ -292,5 +292,9 @@ defmodule EctoResource.OptionParserTest do
       assert OptionParser.create_suffix(TestSchema, suffix: false, except: [:create!, :create]) ==
                ""
     end
+
+    test "when suffix is set to a string, it returns that string directly" do
+      assert OptionParser.create_suffix(TestSchema, suffix: "some_thing") == "some_thing"
+    end
   end
 end


### PR DESCRIPTION
Sometimes the automatically generated suffix might not match what we want. 

For example `SomeSchema.Nested` by default generates as `all_nested` rather than `all_some_schema_nested`. This update will let us pass `suffix: "some_schema_nested"` to manually set this.

Open to feedback on how to approach this, but the PR was simple enough to go ahead and do as a suggestion (and solves for my use case)